### PR TITLE
Make rom_crypto.c symbols private to avoid collisions with TinyDTLS.

### DIFF
--- a/driverlib/rom_crypto.c
+++ b/driverlib/rom_crypto.c
@@ -195,16 +195,16 @@ ECC_initialize(uint32_t *pWorkzone)
 }
 
 typedef uint8_t(*ecc_keygen_t)(uint32_t *, uint32_t *,uint32_t *, uint32_t *);
-ecc_keygen_t ecc_generatekey = (ecc_keygen_t)(0x10017dbd);
+static ecc_keygen_t ecc_generatekey = (ecc_keygen_t)(0x10017dbd);
 
 typedef uint8_t(*ecdsa_sign_t)(uint32_t *, uint32_t *,uint32_t *, uint32_t *, uint32_t *);
-ecdsa_sign_t ecc_ecdsa_sign = (ecdsa_sign_t)(0x10017969);
+static ecdsa_sign_t ecc_ecdsa_sign = (ecdsa_sign_t)(0x10017969);
 
 typedef uint8_t(*ecdsa_verify_t)(uint32_t *, uint32_t *,uint32_t *, uint32_t *, uint32_t *);
-ecdsa_verify_t ecc_ecdsa_verify = (ecdsa_verify_t)(0x10017b01);
+static ecdsa_verify_t ecc_ecdsa_verify = (ecdsa_verify_t)(0x10017b01);
 
 typedef uint8_t(*ecdh_computeSharedSecret_t)(uint32_t *, uint32_t *,uint32_t *, uint32_t *, uint32_t *);
-ecdh_computeSharedSecret_t ecdh_computeSharedSecret = (ecdh_computeSharedSecret_t)(0x10017ded);
+static ecdh_computeSharedSecret_t ecdh_computeSharedSecret = (ecdh_computeSharedSecret_t)(0x10017ded);
 
 //*****************************************************************************
 // ECC_generateKey


### PR DESCRIPTION
When compiling the ``lwm2m-ipso-objects`` example with DTLS support for the TI SensorTag cc2650, I noticed that a symbol defined in [rom_crypto.c](https://github.com/contiki-ng/cc26xxware/blob/master/driverlib/rom_crypto.c#L201) collides with a symbol defined by [TinyDTLS](https://github.com/contiki-ng/tinydtls/blob/55fbfa86a2c6586501e36631c6d7f1cd7a83f0bc/ecc/ecc.h#L53).

Only one symbols of the one for which I changed the visibility collides. However I think that all those symbols should be defined as static in ``rom_crypto.c``.