### PR TITLE
Fix identification of CC2630

### DIFF
--- a/driverlib/chipinfo.c
+++ b/driverlib/chipinfo.c
@@ -145,6 +145,7 @@ ChipInfo_GetChipType( void )
       case 0x4 :
       case 0xC :
          chipType = CHIP_TYPE_CC2630 ;
+         break;
       case 0x1 :
       case 0x9 :
          chipType = CHIP_TYPE_CC2640 ;


### PR DESCRIPTION
This fix allows the CC2630 to be correctly identified. Without it, the rf core mode selection (in rf_core_set_modesel() of rf-core.c) will be set incorrectly for the CC2630 and IEEE commands (eg. CMD_IEEE_RX 0x2801) will fail with CMDSTA= 0x82 (unrecognized command). 

This would also PR address issue #2111 in the contiki-os repo, the PR link there seems broken.
https://github.com/contiki-os/contiki/issues/2111